### PR TITLE
Add dry run functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,9 @@ $ cat test.txt | glack
 Glack Message sent! Channel ID: XXXXXXXXXX Message ID: 145027XXXX.XXXXXXXXXX
 Glack Message sent! Channel ID: XXXXXXXXXX Message ID: 145027XXXX.XXXXXXXXXX
 
+# Test parsing with a dry run
+$ glack -channel "#random" -icon ":fish:" -dry-run "Hello World"
+{Channel:"#random", Username:"Glack", Message:"Hello World", Icon:":fish:"}
 ```
 
 You can use several types of tokens, but the easiest is to get a personal token from the [Slack API](https://api.slack.com/web) documentation. If you want to send a message to yourself you can make a private channel or use `@{username}` as the channel name, replacing with your own username.


### PR DESCRIPTION
@grahn I added a `dry-run` flag to help verify parsing when building complex api commands, and should be pretty simple

I did notice though, that the `sendMessage` method looks like it could be a bit more clear if refactored, any ideas?
